### PR TITLE
Make name replacement pattern match (new?) stage2 libraries

### DIFF
--- a/rust-nightly.rb
+++ b/rust-nightly.rb
@@ -75,7 +75,7 @@ class RustNightly < Formula
   end
 
   def install_name_tool(path, old)
-    pattern = 'x86_64-apple-darwin/stage1/lib/rustlib/x86_64-apple-darwin'
+    pattern = %r(x86_64-apple-darwin/stage\d+/lib/rustlib/x86_64-apple-darwin)
     if path.match(pattern)
       new = old.gsub(pattern, prefix)
       system("install_name_tool -change '#{old}' '#{new}' '#{path}'")


### PR DESCRIPTION
I tried to install the 2015-09-15 nightly last night and ran into some issues with the library names:

```
$ otool -L /usr/local/lib/rustlib/x86_64-apple-darwin/lib/libsyntax-35017696.dylib
/usr/local/lib/rustlib/x86_64-apple-darwin/lib/libsyntax-35017696.dylib:
        /usr/local/lib/rustlib/x86_64-apple-darwin/lib/libsyntax-35017696.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/local/Cellar/rust-nightly/1.0-2015-09-15/lib/libfmt_macros-35017696.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/local/Cellar/rust-nightly/1.0-2015-09-15/lib/libterm-35017696.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/local/Cellar/rust-nightly/1.0-2015-09-15/lib/libserialize-35017696.dylib (compatibility version 0.0.0, current version 0.0.0)
        x86_64-apple-darwin/stage2/lib/rustlib/x86_64-apple-darwin/lib/liblog-35017696.dylib (compatibility version 0.0.0, current version 0.0.0)
        x86_64-apple-darwin/stage2/lib/rustlib/x86_64-apple-darwin/lib/libstd-35017696.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 159.1.0)
```

This patch fixes the 2 `stage2` libraries that didn't get renamed.
