### PR TITLE
Case-insensitive header grep

### DIFF
--- a/rust-nightly.rb
+++ b/rust-nightly.rb
@@ -4,7 +4,7 @@ require 'date'
 class RustNightly < Formula
   def self.latest_rust_nightly_revision
     @latest_rust_nightly_revision ||= begin
-      Date.parse(`curl --silent --HEAD 'https://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz' | grep 'Last-Modified:'`.split(' ', 2).last.strip).to_s
+      Date.parse(`curl --silent --HEAD 'https://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz' | grep -i 'Last-Modified:'`.split(' ', 2).last.strip).to_s
     end
   end
 


### PR DESCRIPTION
Amazon S3's HTTP server presents lowercase headers